### PR TITLE
Remove depricated mcrypt for openssl

### DIFF
--- a/_build/GoogleAuthenticatorX/build.transport.php
+++ b/_build/GoogleAuthenticatorX/build.transport.php
@@ -26,8 +26,8 @@ set_time_limit(0);
 /* define package names */
 define('PKG_NAME', 'GoogleAuthenticatorX');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
-define('PKG_VERSION', '1.2.2');
-define('PKG_RELEASE', 'rc4');
+define('PKG_VERSION', '2.0.0');
+define('PKG_RELEASE', 'rc1');
 
 $root = dirname(dirname(dirname(__FILE__))).'/';
 $sources = array(

--- a/_build/GoogleAuthenticatorX/data/transport.settings.php
+++ b/_build/GoogleAuthenticatorX/data/transport.settings.php
@@ -22,7 +22,8 @@ $s = array(
     'gax_disabled' => true,
     'gax_courtesy_enabled' => true,
     'gax_profile_enabled' => false,
-    'gax_issuer' => ''
+    'gax_issuer' => '',
+    'gax_encrypt_key' => ''
 );
 
 $settings = array();


### PR DESCRIPTION
Removed the deprecated mcrypt for openssl

Ready for QA testing & building to V2.0.0

Feel free if you have any questions regarding the adjustments.